### PR TITLE
Dissociated `in`/`out` from boundaries for uncentered components

### DIFF
--- a/src/component.typ
+++ b/src/component.typ
@@ -51,12 +51,7 @@
                 let style = cetz.styles.resolve(base-style, merge: params.named())
                 scale(p-scale * style.at("scale", default: 1))
                 draw(ctx, position, style)
-                hide(rect("0", "1", name: "rect"))
-                copy-anchors("rect")
-                if position.len() < 2 {
-                    anchor("in", "rect.west")
-                    anchor("out", "rect.east")
-                }
+                copy-anchors("bounds")
             })
         })
 
@@ -78,10 +73,26 @@
 
     if (debug) {
         on-layer(1, {
-            for-each-anchor(name, exclude: ("start", "end", "mid", "component", "line", "rect", "gl", "0", "1"), name => {
-                circle((), radius: .7pt, stroke: red+.2pt)
-                content((rel: (0,3pt)), box(inset: 1pt, text(2pt, name, fill: red)))
+            for-each-anchor(name, exclude: ("start", "end", "mid", "component", "line", "bounds", "gl", "0", "1"), name => {
+                circle((), radius: .7pt, stroke: red + .2pt)
+                content((rel: (0, 3pt)), box(inset: 1pt, text(3pt, name, fill: red)), angle: -30deg)
             })
         })
+    }
+}
+
+#let interface(node1, node2, ..params, io: false) = {
+    import cetz.draw: *
+
+    hide(rect(node1, node2, name: "bounds"))
+    if io {
+        if params.pos().len() == 2 {
+            let (node3, node4) = params.pos()
+        } else {
+            let (node3, node4) = ("bounds.west", "bounds.east")
+        }
+
+        anchor("in", node3)
+        anchor("out", node4)
     }
 }

--- a/src/component.typ
+++ b/src/component.typ
@@ -78,8 +78,9 @@
 
     if (debug) {
         on-layer(1, {
-            for-each-anchor(name, exclude: ("start", "end", "mid"), name => {
-                content((), box(inset: 1pt, fill: black, text(4pt, name, fill: white)))
+            for-each-anchor(name, exclude: ("start", "end", "mid", "component", "line", "rect", "gl", "0", "1"), name => {
+                circle((), radius: .7pt, stroke: red+.2pt)
+                content((rel: (0,3pt)), box(inset: 1pt, text(2pt, name, fill: red)))
             })
         })
     }

--- a/src/component.typ
+++ b/src/component.typ
@@ -86,10 +86,11 @@
 
     hide(rect(node1, node2, name: "bounds"))
     if io {
+        let (node3, node4) = (0,0)
         if params.pos().len() == 2 {
-            let (node3, node4) = params.pos()
+            (node3, node4) = params.pos()
         } else {
-            let (node3, node4) = ("bounds.west", "bounds.east")
+            (node3, node4) = ("bounds.west", "bounds.east")
         }
 
         anchor("in", node3)

--- a/src/components/capacitors.typ
+++ b/src/components/capacitors.typ
@@ -1,4 +1,4 @@
-#import "/src/component.typ": component
+#import "/src/component.typ": component, interface
 #import "/src/dependencies.typ": cetz
 #import cetz.draw: anchor, line
 #import "/src/mini.typ": variable-arrow
@@ -14,8 +14,7 @@
 
     // Drawing function
     let draw(ctx, position, style) = {
-        anchor("0", (-style.distance / 2, -style.width / 2))
-        anchor("1", (style.distance / 2, style.width / 2))
+        interface((-style.distance / 2, -style.width / 2), (style.distance / 2, style.width / 2), io: position.len() < 2)
 
         line((-style.distance / 2, -style.width / 2), (-style.distance / 2, style.width / 2), ..style)
         line((style.distance / 2, -style.width / 2), (style.distance / 2, style.width / 2), ..style)

--- a/src/components/diodes.typ
+++ b/src/components/diodes.typ
@@ -1,4 +1,4 @@
-#import "/src/component.typ": component
+#import "/src/component.typ": component, interface
 #import "/src/dependencies.typ": cetz
 #import cetz.draw: anchor, circle, line, polygon, scope, translate
 #import "/src/mini.typ": radiation-arrows
@@ -16,8 +16,7 @@
     // Drawing function
     let draw(ctx, position, style) = {
         translate((-style.radius / 4, 0))
-        anchor("0", (-style.radius / 2, -style.radius))
-        anchor("1", (style.radius, style.radius))
+        interface((-style.radius / 2, -style.radius), (style.radius, style.radius), io: position.len() < 2)
 
         polygon((0, 0), 3, radius: style.radius, fill: white, ..style)
         line((0deg, style.radius), (180deg, style.radius / 2), ..style.at("wires"))

--- a/src/components/fuses.typ
+++ b/src/components/fuses.typ
@@ -1,4 +1,4 @@
-#import "/src/component.typ": component
+#import "/src/component.typ": component, interface
 #import "/src/dependencies.typ": cetz
 #import cetz.draw: anchor, circle, floating, line, rect
 
@@ -14,8 +14,7 @@
 
     // Drawing function
     let draw(ctx, position, style) = {
-        anchor("0", (-style.width / 2, -style.height / 2))
-        anchor("1", (style.width / 2, style.height / 2))
+        interface((-style.width / 2, -style.height / 2), (style.width / 2, style.height / 2), io: position.len() < 2)
 
         rect((-style.width / 2, -style.height / 2), (style.width / 2, style.height / 2), fill: white, ..style)
         line((-style.width / 2, 0), (style.width / 2, 0), ..style.at("wires"))

--- a/src/components/grounds.typ
+++ b/src/components/grounds.typ
@@ -1,4 +1,4 @@
-#import "/src/component.typ": component
+#import "/src/component.typ": component, interface
 #import "/src/dependencies.typ": cetz
 #import cetz.draw: anchor, line, polygon
 #import "/src/mini.typ": radiation-arrows
@@ -18,8 +18,7 @@
         polygon((0, -style.distance), 3, anchor: "north", radius: style.radius, angle: -90deg, name: "polygon", ..style)
 
         let (width, height) = cetz.util.measure(ctx, "polygon")
-        anchor("0", (-width / 2, -height / 2))
-        anchor("1", (width / 2, height / 2))
+        interface((-width / 2, -height / 2), (width / 2, height / 2))
     }
 
     // Componant call
@@ -45,8 +44,7 @@
         for i in (0, 1, 2) {
             line((-style.width / 2 + (1 - i) * .01 + i * delta, -style.distance), (rel: (angle: -style.angle - 90deg, radius: style.depth)), ..style)
         }
-        anchor("0", (-style.width / 2, style.distance))
-        anchor("1", (style.width / 2, -style.distance))
+        interface((-style.width / 2, style.distance), (style.width / 2, -style.distance))
     }
 
     // Componant call
@@ -74,8 +72,7 @@
                 ..style,
             )
         }
-        anchor("0", (-style.width / 2, -style.distance - style.spacing * 2))
-        anchor("1", (style.width / 2, -style.distance))
+        interface((-style.width / 2, -style.distance - style.spacing * 2), (style.width / 2, -style.distance))
     }
 
     // Componant call

--- a/src/components/inductors.typ
+++ b/src/components/inductors.typ
@@ -1,4 +1,4 @@
-#import "/src/component.typ": component
+#import "/src/component.typ": component, interface
 #import "/src/dependencies.typ": cetz
 #import cetz.draw: anchor, arc, line, rect
 
@@ -12,8 +12,7 @@
 
     // Drawing function
     let draw(ctx, position, style) = {
-        anchor("0", (-style.width / 2, -style.height / 2))
-        anchor("1", (style.width / 2, style.height / 2))
+        interface((-style.width / 2, -style.height / 2), (style.width / 2, style.height / 2), io: position.len() < 2)
 
         let bump-radius = style.width / style.bumps / 2
         if (style.variant == "iec") {

--- a/src/components/motors.typ
+++ b/src/components/motors.typ
@@ -1,4 +1,4 @@
-#import "/src/component.typ": component
+#import "/src/component.typ": component, interface
 #import "/src/dependencies.typ": cetz
 #import cetz.draw: anchor, arc, circle, content, rect
 #import "/src/mini.typ": ac-sign, dc-sign
@@ -17,8 +17,7 @@
 
     // Drawing function
     let draw(ctx, position, style) = {
-        anchor("0", (-style.radius, -style.radius))
-        anchor("1", (style.radius, style.radius))
+        interface((-style.radius, -style.radius), (style.radius, style.radius), io: position.len() < 2)
 
         if (magnet) {
             rect((-style.magnet-width / 2, -style.magnet-height / 2), (style.magnet-width / 2, style.magnet-height / 2), fill: black)

--- a/src/components/opamp.typ
+++ b/src/components/opamp.typ
@@ -1,4 +1,4 @@
-#import "/src/component.typ": component
+#import "/src/component.typ": component, interface
 #import "/src/dependencies.typ": cetz
 #import cetz.draw: anchor, content, line, polygon, rect, scope, translate
 
@@ -17,7 +17,10 @@
 
     // Drawing function
     let draw(ctx, position, style) = {
+        interface((-style.width / 2, -style.height / 2), (style.width / 2, style.height / 2))
+
         let sgn = if invert { -1 } else { 1 }
+        anchor("out", (style.width * 2 / 3, 0))
         anchor("minus", (-style.width / 2, sgn * style.sign-delta))
         anchor("plus", (-style.width / 2, -sgn * style.sign-delta))
 
@@ -26,12 +29,10 @@
         } else {
             scope({
                 if style.variant == "ieee" { translate((-style.width / 6, 0)) }
-                polygon((0, 0), 3, radius: style.width * 0.66666, ..style)
+                polygon((0, 0), 3, radius: style.width * 2 / 3, ..style)
             })
         }
 
-        anchor("0", (-style.width / 2, -style.height / 2))
-        anchor("1", (style.width / 2, style.height / 2))
         line((rel: (style.padding - style.sign-size, 0), to: "minus"), (rel: (2 * style.sign-size, 0)), stroke: style.sign-stroke)
         line((rel: (style.padding - style.sign-size, 0), to: "plus"), (rel: (2 * style.sign-size, 0)), stroke: style.sign-stroke)
         line((rel: (style.padding, -style.sign-size), to: "plus"), (rel: (0, 2 * style.sign-size)), stroke: style.sign-stroke)

--- a/src/components/opamp.typ
+++ b/src/components/opamp.typ
@@ -17,10 +17,9 @@
 
     // Drawing function
     let draw(ctx, position, style) = {
-        interface((-style.width / 2, -style.height / 2), (style.width / 2, style.height / 2))
+        interface((-style.width / 2, -style.height / 2), (style.width / 2, style.height / 2), io: true)
 
         let sgn = if invert { -1 } else { 1 }
-        anchor("out", (style.width * 2 / 3, 0))
         anchor("minus", (-style.width / 2, sgn * style.sign-delta))
         anchor("plus", (-style.width / 2, -sgn * style.sign-delta))
 

--- a/src/components/resistors.typ
+++ b/src/components/resistors.typ
@@ -1,4 +1,4 @@
-#import "/src/component.typ": component
+#import "/src/component.typ": component, interface
 #import "/src/dependencies.typ": cetz
 #import cetz.draw: anchor, line, rect
 #import "/src/mini.typ": variable-arrow
@@ -16,8 +16,7 @@
 
     // Drawing function
     let draw(ctx, position, style) = {
-        anchor("0", (-style.width / 2, -style.height / 2))
-        anchor("1", (style.width / 2, style.height / 2))
+        interface((-style.width / 2, -style.height / 2), (style.width / 2, style.height / 2), io: position.len() < 2)
 
         if style.variant == "iec" {
             rect(

--- a/src/components/sources.typ
+++ b/src/components/sources.typ
@@ -1,4 +1,4 @@
-#import "/src/component.typ": component
+#import "/src/component.typ": component, interface
 #import "/src/dependencies.typ": cetz
 #import cetz.draw: anchor, circle, line, mark, rect
 
@@ -14,8 +14,7 @@
 
     // Drawing function
     let draw(ctx, position, style) = {
-        anchor("0", (-style.radius, -style.radius))
-        anchor("1", (style.radius, style.radius))
+        interface((-style.radius, -style.radius), (style.radius, style.radius), io: position.len() < 2)
 
         circle((0, 0), radius: style.radius, fill: white, ..style)
         if (style.variant == "iec") {
@@ -45,8 +44,7 @@
 
     // Drawing function
     let draw(ctx, position, style) = {
-        anchor("0", (-style.radius, -style.radius))
-        anchor("1", (style.radius, style.radius))
+        interface((-style.radius, -style.radius), (style.radius, style.radius), io: position.len() < 2)
 
         circle((0, 0), radius: style.radius, fill: white, ..style)
         if (style.variant == "iec") {

--- a/src/components/transistors/bjts.typ
+++ b/src/components/transistors/bjts.typ
@@ -1,6 +1,6 @@
 #import "/src/component.typ": component
 #import "/src/dependencies.typ": cetz
-#import cetz.draw: anchor, circle, line, mark, translate, hide
+#import cetz.draw: anchor, circle, hide, line, mark, translate
 #import "/src/mini.typ": center-mark
 
 #let bjt(name, node, polarisation: "npn", envelope: false, ..params) = {
@@ -16,7 +16,7 @@
         aperture: 50deg,
     )
 
-    // Drawing functions
+    // Drawing function
     let draw(ctx, position, style) = {
         anchor("0", (0, 0))
         anchor("1", (0, style.base-height / 2))

--- a/src/components/transistors/bjts.typ
+++ b/src/components/transistors/bjts.typ
@@ -1,4 +1,4 @@
-#import "/src/component.typ": component
+#import "/src/component.typ": component, interface
 #import "/src/dependencies.typ": cetz
 #import cetz.draw: anchor, circle, hide, line, mark, translate
 #import "/src/mini.typ": center-mark
@@ -18,8 +18,7 @@
 
     // Drawing function
     let draw(ctx, position, style) = {
-        anchor("0", (0, 0))
-        anchor("1", (0, style.base-height / 2))
+        interface((0, 0), (0, style.base-height / 2))
 
         let sgn = if polarisation == "npn" { -1 } else { 1 }
         anchor("base", ((-style.radius, 0), 30%, (style.radius, 0)))

--- a/src/components/transistors/bjts.typ
+++ b/src/components/transistors/bjts.typ
@@ -18,7 +18,7 @@
 
     // Drawing function
     let draw(ctx, position, style) = {
-        interface((0, 0), (0, style.base-height / 2))
+        interface((-style.radius, -style.radius), (style.radius, style.radius))
 
         let sgn = if polarisation == "npn" { -1 } else { 1 }
         anchor("base", ((-style.radius, 0), 30%, (style.radius, 0)))
@@ -32,9 +32,9 @@
 
         if envelope {
             line("base", (-style.radius, 0), ..style.at("wires"))
-            circle((0, 0), radius: style.radius, ..style, name: "c")
+            circle((0, 0), radius: style.radius, ..style, name: "circle")
         } else {
-            hide(circle((0, 0), radius: style.radius, ..style, name: "c"))
+            hide(circle((0, 0), radius: style.radius, ..style, name: "circle"))
         }
     }
 

--- a/src/components/transistors/mosfets.typ
+++ b/src/components/transistors/mosfets.typ
@@ -1,6 +1,6 @@
 #import "/src/component.typ": component
 #import "/src/dependencies.typ": cetz
-#import cetz.draw: anchor, circle, floating, line, mark, set-origin, translate, content, hide
+#import cetz.draw: anchor, circle, content, floating, hide, line, mark, set-origin, translate
 
 #let mosfet(
     name,
@@ -16,54 +16,43 @@
     assert(channel in ("p", "n"), message: "channel must be `p` or `n`")
     assert(bulk in ("internal", "external", none), message: "substrate must be `internal`, `external` or none")
 
-    // TODO: move to defaults
-    let wires-length = 7pt
-    let component-stroke = 1pt
-    let wires-stroke = 0.6pt
+    // Mosfet style
+    let style = (
+        height: .53,
+        width: .71,
+        base-width: .9,
+        base-spacing: .11,
+        base-distance: .11,
+        radius: .7,
+    )
 
-    // Style constants
-    let width = 20pt
-    let base-spacing = 3pt
-    let base-width = width + 8pt
-    let bar-length = (base-width - 2 * base-spacing) / 3
-    let height = 15pt
-    let base-delta = 0pt
-    let radius = .65
-
-    // Drawing functions
+    // Drawing function
     let draw(ctx, position, style) = {
-            anchor("0", (0, 0))
-            anchor("1", (0, height / 2))
+        let (height, width, base-width, base-spacing, radius) = style
+        anchor("0", (-height, -width/2))
+        anchor("1", (0, width / 2))
 
-            let center = (-height / 2, 0)
+        let center = (-height / 2, 0)
 
-            anchor("drain", (0, width / 2 + wires-length))
-            anchor("source", (0, -width / 2 - wires-length))
-            if bulk == "external" {
-                anchor("bulk", (0, 0))
-            }
+        anchor("d", (0, width / 2))
+        anchor("s", (0, -width / 2))
+        if bulk == "external" {
+            anchor("bulk", (0, 0))
+        }
 
-            if mode == "enhancement" {
-                let bar-length = (base-width - 2 * base-spacing) / 3
-                for i in range(3) {
-                    line(
-                      (
-                          (
-                              -height,
-                              -base-width / 2 + i * (bar-length + base-spacing),
-                          )
-                      ),
-                      (rel: (0, bar-length)),
-                    )
-                }
-            } else {
-                line((-height, -base-width / 2), (rel: (0, base-width)))
+        if mode == "enhancement" {
+            let bar-length = (base-width - 2 * base-spacing) / 3
+            for i in range(3) {
+                line(((-height, -base-width / 2 + i * (bar-length + base-spacing))), (rel: (0, bar-length)), ..style)
             }
-            if bulk == "internal" {
-                line((0, 0), (0, -width / 2), stroke: wires-stroke)
-            }
-            line("drain", (rel: (0, -wires-length)), (rel: (-height, 0)), stroke: wires-stroke)
-            line("source", (rel: (0, wires-length)), (rel: (-height, 0)), stroke: wires-stroke)
+        } else {
+            line((-height, -base-width / 2), (rel: (0, base-width)), ..style)
+        }
+        if bulk == "internal" {
+            line((0, 0), (0, -width / 2), ..style.at("wires"))
+        }
+        line("d", (rel: (0, 0)), (rel: (-height, 0)), ..style.at("wires"))
+        line("s", (rel: (0, 0)), (rel: (-height, 0)), ..style.at("wires"))
 
         if envelope {
             circle(center, radius: radius, ..style, name: "c")
@@ -72,33 +61,33 @@
         }
 
         anchor("gl", (rel: (-3 * height / 4, width / 2), to: center))
-        
-            if bulk != none {
-                line((-height, 0), (rel: (height, 0)), name: "line", stroke: wires-stroke)
-                mark("line.centroid", (-height, 0), symbol: if (channel == "n") { ">" } else { "<" }, fill: black, scale: 0.8, anchor: "center")
-                line("gl", (rel: (0, -width)), (rel: (-height / 4, 0)), stroke: wires-stroke)
-                anchor("gate", ())
-            } else {
-                line("gl", (rel: (0, -width/2)), (rel: (0, -width/2)), stroke: wires-stroke)
-                line((rel: (0, width/2)), (rel: (-height / 2, 0)), stroke: wires-stroke)
-                anchor("gate", ())
 
-                mark(
-                    (
-                        -height / 2,
-                        if (channel == "n") { -width / 2 } else { width / 2 },
-                    ),
-                    (rel: (height, 0)),
-                    symbol: if (channel == "n") { ">" } else { "<" },
-                    fill: black,
-                    scale: 0.8,
-                    anchor: "center",
-                )
-            }
+        if bulk != none {
+            line((-height, 0), (rel: (height, 0)), name: "line", ..style.at("wires"))
+            mark("line.centroid", (-height, 0), symbol: if (channel == "n") { ">" } else { "<" }, fill: black, scale: 0.8, anchor: "center")
+            line("gl", (rel: (0, -width)), (rel: (-height / 4, 0)), ..style.at("wires"))
+            anchor("g", ())
+        } else {
+            line("gl", (rel: (0, -width / 2)), (rel: (0, -width / 2)), ..style.at("wires"))
+            line((rel: (0, width / 2)), (rel: (-height / 2, 0)), ..style.at("wires"))
+            anchor("g", ())
+
+            mark(
+                (
+                    -height / 2,
+                    if (channel == "n") { -width / 2 } else { width / 2 },
+                ),
+                (rel: (height, 0)),
+                symbol: if (channel == "n") { ">" } else { "<" },
+                fill: black,
+                scale: 0.8,
+                anchor: "center",
+            )
         }
+    }
 
     // Componant call
-    component("mosfet", name, node, draw: draw, ..params)
+    component("mosfet", name, node, draw: draw, style: style, ..params)
 }
 
 #let pmos(name, node, ..params) = mosfet(name, node, channel: "p", ..params)

--- a/src/components/transistors/mosfets.typ
+++ b/src/components/transistors/mosfets.typ
@@ -1,4 +1,4 @@
-#import "/src/component.typ": component
+#import "/src/component.typ": component, interface
 #import "/src/dependencies.typ": cetz
 #import cetz.draw: anchor, circle, content, floating, hide, line, mark, set-origin, translate
 
@@ -29,8 +29,7 @@
     // Drawing function
     let draw(ctx, position, style) = {
         let (height, width, base-width, base-spacing, radius) = style
-        anchor("0", (-height, -width/2))
-        anchor("1", (0, width / 2))
+        interface((-height, -width / 2), (0, width / 2))
 
         let center = (-height / 2, 0)
 
@@ -43,7 +42,7 @@
         if mode == "enhancement" {
             let bar-length = (base-width - 2 * base-spacing) / 3
             for i in range(3) {
-                line(((-height, -base-width / 2 + i * (bar-length + base-spacing))), (rel: (0, bar-length)), ..style)
+                line((-height, -base-width / 2 + i * (bar-length + base-spacing)), (rel: (0, bar-length)), ..style)
             }
         } else {
             line((-height, -base-width / 2), (rel: (0, base-width)), ..style)


### PR DESCRIPTION
Some components like microphones do not have a centered components, hence the `in`/`out` do not match with the `east` and `west` anchors of the component's boundaries.
This PR introduces a function `interface` to quickly define the anchors used externally.