### PR TITLE
New `vcc` component

### DIFF
--- a/src/components/grounds.typ
+++ b/src/components/grounds.typ
@@ -78,3 +78,24 @@
     // Componant call
     component("earth", name, node, draw: draw, style: style, ..params)
 }
+
+#let vcc(name, node, ..params) = {
+    // VCC style
+    let style = (
+        angle: 35deg,
+        radius: .4,
+        distance: .6,
+    )
+
+    // Drawing function
+    let draw(ctx, position, style) = {
+        line((0, 0), (0, style.distance), ..style.at("wires"))
+        line( (rel: (radius: style.radius, angle: -90deg -style.angle), to: (0, style.distance)), (0, style.distance), (rel: (radius: style.radius, angle: -90deg + style.angle)))
+
+        let (width, height) = (calc.sin(style.angle)*style.radius, calc.cos(style.angle)*style.radius)
+        interface((-width / 2, -height / 2), (width / 2, height / 2))
+    }
+
+    // Componant call
+    component("vcc", name, node, draw: draw, style: style, ..params)
+}

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -12,7 +12,7 @@
 #import "components/diodes.typ": diode, led, photodiode
 #import "components/opamp.typ": opamp
 #import "components/fuses.typ": afuse, fuse
-#import "components/grounds.typ": earth, frame, ground
+#import "components/grounds.typ": earth, frame, ground, vcc
 #import "components/inductors.typ": inductor
 #import "components/resistors.typ": potentiometer, resistor, rheostat
 #import "components/sources.typ": isource, vsource

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zap"
-version = "0.2.0"
+version = "0.2.1"
 compiler = "0.13.0"
 entrypoint = "src/lib.typ"
 authors = ["Louis Grange <https://github.com/l0uisgrange>"]


### PR DESCRIPTION
This PR adds a new component to represent external voltage sources

```typst
#zap.canvas({
    import zap: *

    vcc("v", (0,0))
})
```

![positioning](https://github.com/user-attachments/assets/89b14e87-48c4-4884-86f8-9459f8111ae5)

