### PR TITLE
fix 'Unknown variable: padding' for non iec variant isources

### DIFF
--- a/src/components/sources.typ
+++ b/src/components/sources.typ
@@ -20,7 +20,7 @@
         if (style.variant == "iec") {
             line((0, -style.radius), (rel: (0, 2 * style.radius)), ..style, fill: none)
         } else {
-            line((-style.radius + padding, 0), (rel: (2 * style.radius - 1.85 * padding, 0)), mark: (end: ">"), fill: black)
+            line((-style.radius + style.padding, 0), (rel: (2 * style.radius - 1.85 * style.padding, 0)), mark: (end: ">"), fill: black)
         }
     }
 


### PR DESCRIPTION
I had an error compiling with @preview/zap:0.2.0 when using non-iec style current sources. there seems to have been a regression on [9820e97](https://github.com/l0uisgrange/zap/commit/9820e97ffd216cf83ac66042fdf1f349ac44964b) when adding `style` to isource as it did not change how padding was accessed.