### PR TITLE
chore(deps): bumped `@preview/cetz:0.4.0`

### DIFF
--- a/src/dependencies.typ
+++ b/src/dependencies.typ
@@ -1,1 +1,1 @@
-#import "@preview/cetz:0.3.4"
+#import "@preview/cetz:0.4.0"


### PR DESCRIPTION
Bumped cetz to today's `0.4.0` release.