### PR TITLE
fix: standard `led` arrows direction 

### DIFF
--- a/src/components/diodes.typ
+++ b/src/components/diodes.typ
@@ -22,7 +22,7 @@
         line((0deg, style.radius), (180deg, style.radius / 2), ..style.at("wires"))
         line((style.radius, -style.line), (style.radius, style.line), ..style)
         if (emitting or receiving) {
-            radiation-arrows((to: (0, 0), rel: (0.4, 0.6)), angle: -135deg, reversed: receiving, length: 12pt)
+            radiation-arrows((to: (0, 0), rel: (0.25, 0.65)), reversed: receiving)
         }
     }
 

--- a/src/components/grounds.typ
+++ b/src/components/grounds.typ
@@ -1,7 +1,6 @@
 #import "/src/component.typ": component, interface
 #import "/src/dependencies.typ": cetz
 #import cetz.draw: anchor, line, polygon
-#import "/src/mini.typ": radiation-arrows
 
 #let ground(name, node, ..params) = {
     assert(params.pos().len() == 0, message: "ground supports only one node")

--- a/src/mini.typ
+++ b/src/mini.typ
@@ -21,9 +21,9 @@
     })
 }
 
-#let radiation-arrows(origin, angle: -30deg, reversed: false, length: 14pt) = {
+#let radiation-arrows(origin, angle: -120deg, reversed: false, length: 12pt) = {
     scope({
-        let arrows-distance = 2.5pt
+        let arrows-distance = 3pt
         let arrows-length = length
         let arrows-scale = 0.8
 


### PR DESCRIPTION
Thanks for the cool project!

I saw, that the LED arrows are the wrong way around (they should face toward the LED's cathode). This request attempts to fix this behaviour. Furthermore, the arrows are a bit more modular (angle/ length are in function header).