### PR TITLE
fix: wires facing opposite directions

### DIFF
--- a/src/component.typ
+++ b/src/component.typ
@@ -84,7 +84,7 @@
         // Decorations
         if position.len() == 2 {
             line("in", "component.west", ..pre-style.at("wires"))
-            line("out", "component.east", ..pre-style.at("wires"))
+            line("component.east", "out", ..pre-style.at("wires"))
 
             if i != none {
                 current(ctx, i)


### PR DESCRIPTION
When styling wires e.g. to show the directions of current, the wires face opposite directions. This PR fixes this. 

Example:
```typst
#zap.canvas({
    import zap: *

    set-style(zap: (
        wires: (mark: (end: ">"))
    ))


    // Wheatstone bridge
    resistor("r1", (4,0), (6,2), label: "R1", adjustable: true)
    resistor("r2", (6,2), (4,4), label: "R2", label-angle: 180deg)
    resistor("r3", (4,0), (2,2), label: "R3")
    resistor("r4", (2,2), (4,4), label: "R4", label-angle: -180deg)

    // Voltage source
    vsource("v1", (0,0), (0,4), label: "3V")

    // Capacitor & motor
    capacitor("c1", "r2.out", (8,4), label: "C1")
    dcmotor("m1", "c1.out", (rel: (0,-4)))

    // Wiring
    wire("v1.in", "m1.out")
    wire("v1.out", "r4.out")
})
```
Before:
<img width="406" height="223" alt="image" src="https://github.com/user-attachments/assets/21b19e8e-4a4e-4c62-aeed-e90678d32c9f" />

After:
<img width="406" height="228" alt="image" src="https://github.com/user-attachments/assets/2eba334f-d4bd-460d-ad56-2aae0b674620" />
