### PR TITLE
feat(component): new dependent sources

### DIFF
--- a/src/component.typ
+++ b/src/component.typ
@@ -60,9 +60,8 @@
             group(name: "component", {
                 if (type(p-scale) == float) {
                     scale(p-scale * style.at("scale", default: 1))
-                }
-                else {
-                    scale(x: p-scale.at(0, default: 1) * style.at("scale", default: 1),y: p-scale.at(1, default: 1) * style.at("scale", default: 1))
+                } else {
+                    scale(x: p-scale.at(0, default: 1) * style.at("scale", default: 1), y: p-scale.at(1, default: 1) * style.at("scale", default: 1))
                 }
                 draw(ctx, position, style)
                 copy-anchors("bounds")

--- a/src/components/sources.typ
+++ b/src/components/sources.typ
@@ -19,7 +19,7 @@
         interface((-style.radius, -style.radius), (style.radius, style.radius), io: position.len() < 2)
 
         if dependent {
-            polygon((0, 0), 4, radius: style.radius, fill: white, ..style)
+            polygon((0, 0), 4, radius: style.radius * 1.1, fill: white, ..style)
         } else {
             circle((0, 0), radius: style.radius, fill: white, ..style)
         }
@@ -37,7 +37,7 @@
 #let disource(name, node, ..params) = isource(name, node, dependent: true, ..params)
 #let acisource(name, node, ..params) = isource(name, node, current: "ac", ..params)
 
-#let vsource(name, node, current: "dc", ..params) = {
+#let vsource(name, node, dependent: false, current: "dc", ..params) = {
     assert(current in ("dc", "ac"), message: "current must be ac or dc")
 
     // Vsource style
@@ -53,18 +53,23 @@
     let draw(ctx, position, style) = {
         interface((-style.radius, -style.radius), (style.radius, style.radius), io: position.len() < 2)
 
-        circle((0, 0), radius: style.radius, fill: white, ..style)
-        if (style.variant == "iec") {
+        if dependent {
+            polygon((0, 0), 4, radius: style.radius * 1.1, fill: white, ..style)
+        } else {
+            circle((0, 0), radius: style.radius, fill: white, ..style)
+        }
+        if style.variant == "iec" {
             if current == "ac" {
                 content((0, 0), [#cetz.canvas({ ac-sign(size: 2) })])
             } else {
                 line((-style.radius, 0), (rel: (2 * style.radius, 0)), ..style)
             }
         } else {
-            line((rel: (-style.radius + style.padding, -style.sign-size)), (rel: (0, 2 * style.sign-size)), stroke: style.sign-stroke)
+            let factor = if dependent { 0.9 } else { 1 }
+            line((rel: (-style.radius * factor + style.padding, -style.sign-size)), (rel: (0, 2 * style.sign-size)), stroke: style.sign-stroke)
             line(
                 (
-                    style.radius - style.padding - style.sign-delta,
+                    style.radius * factor - style.padding - style.sign-delta,
                     -style.sign-size,
                 ),
                 (rel: (0, 2 * style.sign-size)),
@@ -78,5 +83,5 @@
     component("vsource", name, node, draw: draw, style: style, ..params)
 }
 
-#let dvsource(name, node, ..params) = isource(name, node, dependent: true, ..params)
+#let dvsource(name, node, ..params) = vsource(name, node, dependent: true, ..params)
 #let acvsource(name, node, ..params) = vsource(name, node, current: "ac", ..params)

--- a/src/components/sources.typ
+++ b/src/components/sources.typ
@@ -16,10 +16,11 @@
 
     // Drawing function
     let draw(ctx, position, style) = {
-        interface((-style.radius, -style.radius), (style.radius, style.radius), io: position.len() < 2)
+        let factor = if dependent { 1.1 } else { 1 }
+        interface((-style.radius * factor, -style.radius * factor), (style.radius * factor, style.radius * factor), io: position.len() < 2)
 
         if dependent {
-            polygon((0, 0), 4, radius: style.radius * 1.1, fill: white, ..style)
+            polygon((0, 0), 4, fill: white, ..style, radius: style.radius * factor)
         } else {
             circle((0, 0), radius: style.radius, fill: white, ..style)
         }
@@ -51,12 +52,13 @@
 
     // Drawing function
     let draw(ctx, position, style) = {
-        interface((-style.radius, -style.radius), (style.radius, style.radius), io: position.len() < 2)
+        let factor = if dependent { 1.1 } else { 1 }
+        interface((-style.radius * factor, -style.radius * factor), (style.radius * factor, style.radius * factor), io: position.len() < 2)
 
         if dependent {
-            polygon((0, 0), 4, radius: style.radius * 1.1, fill: white, ..style)
+            polygon((0, 0), 4, fill: white, ..style, radius: style.radius * factor)
         } else {
-            circle((0, 0), radius: style.radius, fill: white, ..style)
+            circle((0, 0), fill: white, ..style)
         }
         if style.variant == "iec" {
             if current == "ac" {
@@ -65,11 +67,10 @@
                 line((-style.radius, 0), (rel: (2 * style.radius, 0)), ..style)
             }
         } else {
-            let factor = if dependent { 0.9 } else { 1 }
-            line((rel: (-style.radius * factor + style.padding, -style.sign-size)), (rel: (0, 2 * style.sign-size)), stroke: style.sign-stroke)
+            line((rel: (-style.radius + style.padding, -style.sign-size)), (rel: (0, 2 * style.sign-size)), stroke: style.sign-stroke)
             line(
                 (
-                    style.radius * factor - style.padding - style.sign-delta,
+                    style.radius - style.padding - style.sign-delta,
                     -style.sign-size,
                 ),
                 (rel: (0, 2 * style.sign-size)),

--- a/src/components/sources.typ
+++ b/src/components/sources.typ
@@ -1,9 +1,10 @@
 #import "/src/component.typ": component, interface
 #import "/src/dependencies.typ": cetz
 #import "/src/mini.typ": ac-sign
-#import cetz.draw: anchor, circle, content, line, mark, rect
+#import cetz.draw: anchor, circle, content, line, mark, rect, polygon
 
-#let isource(name, node, current: "dc", ..params) = {
+#let isource(name, node, dependent: false, current: "dc", ..params) = {
+    assert(type(dependent) == bool, message: "dependent must be boolean")
     assert(current in ("dc", "ac"), message: "current must be ac or dc")
 
     // Isource style
@@ -17,7 +18,11 @@
     let draw(ctx, position, style) = {
         interface((-style.radius, -style.radius), (style.radius, style.radius), io: position.len() < 2)
 
-        circle((0, 0), radius: style.radius, fill: white, ..style)
+        if dependent {
+            polygon((0, 0), 4, radius: style.radius, fill: white, ..style)
+        } else {
+            circle((0, 0), radius: style.radius, fill: white, ..style)
+        }
         if (style.variant == "iec") {
             line((0, -style.radius), (rel: (0, 2 * style.radius)), ..style, fill: none)
         } else {
@@ -29,6 +34,7 @@
     component("isource", name, node, draw: draw, style: style, ..params)
 }
 
+#let disource(name, node, ..params) = isource(name, node, dependent: true, ..params)
 #let acisource(name, node, ..params) = isource(name, node, current: "ac", ..params)
 
 #let vsource(name, node, current: "dc", ..params) = {
@@ -72,4 +78,5 @@
     component("vsource", name, node, draw: draw, style: style, ..params)
 }
 
+#let dvsource(name, node, ..params) = isource(name, node, dependent: true, ..params)
 #let acvsource(name, node, ..params) = vsource(name, node, current: "ac", ..params)

--- a/src/components/sources.typ
+++ b/src/components/sources.typ
@@ -1,7 +1,7 @@
 #import "/src/component.typ": component, interface
 #import "/src/dependencies.typ": cetz
 #import "/src/mini.typ": ac-sign
-#import cetz.draw: anchor, circle, content, line, mark, rect, polygon
+#import cetz.draw: anchor, circle, content, line, mark, polygon, rect
 
 #let isource(name, node, dependent: false, current: "dc", ..params) = {
     assert(type(dependent) == bool, message: "dependent must be boolean")
@@ -23,7 +23,7 @@
         } else {
             circle((0, 0), radius: style.radius, fill: white, ..style)
         }
-        if (style.variant == "iec") {
+        if style.variant == "iec" {
             line((0, -style.radius), (rel: (0, 2 * style.radius)), ..style, fill: none)
         } else {
             line((-style.radius + style.padding, 0), (rel: (2 * style.radius - 1.85 * style.padding, 0)), mark: (end: ">"), fill: black)

--- a/src/components/sources.typ
+++ b/src/components/sources.typ
@@ -25,7 +25,7 @@
             circle((0, 0), radius: style.radius, fill: white, ..style)
         }
         if style.variant == "iec" {
-            line((0, -style.radius), (rel: (0, 2 * style.radius)), ..style, fill: none)
+            line((0, -style.radius * factor), (rel: (0, 2 * style.radius * factor)), ..style, fill: none)
         } else {
             line((-style.radius + style.padding, 0), (rel: (2 * style.radius - 1.85 * style.padding, 0)), mark: (end: ">"), fill: black)
         }
@@ -64,7 +64,7 @@
             if current == "ac" {
                 content((0, 0), [#cetz.canvas({ ac-sign(size: 2) })])
             } else {
-                line((-style.radius, 0), (rel: (2 * style.radius, 0)), ..style)
+                line((-style.radius * factor, 0), (rel: (2 * style.radius * factor, 0)), ..style)
             }
         } else {
             line((rel: (-style.radius + style.padding, -style.sign-size)), (rel: (0, 2 * style.sign-size)), stroke: style.sign-stroke)

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -19,7 +19,7 @@
 #import "components/supplies.typ": earth, frame, ground, vcc, vee
 #import "components/inductors.typ": inductor
 #import "components/resistors.typ": potentiometer, resistor, rheostat
-#import "components/sources.typ": acvsource, isource, vsource
+#import "components/sources.typ": acvsource, isource, vsource, disource, dvsource
 #import "components/motors.typ": acmotor, dcmotor
 
 // Export transistors

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -19,7 +19,7 @@
 #import "components/supplies.typ": earth, frame, ground, vcc, vee
 #import "components/inductors.typ": inductor
 #import "components/resistors.typ": potentiometer, resistor, rheostat
-#import "components/sources.typ": acvsource, isource, vsource, disource, dvsource
+#import "components/sources.typ": acvsource, disource, dvsource, isource, vsource
 #import "components/motors.typ": acmotor, dcmotor
 
 // Export transistors


### PR DESCRIPTION
This introduces a `dependent` option on voltage and current sources ⚡️.

| Classic source | Dependent |
|:--------:|:--------:|
| ![main](https://github.com/user-attachments/assets/9f6c18fd-62b3-4190-8c00-2329d03359e8) | ![main](https://github.com/user-attachments/assets/2322bc62-e5e6-4213-87e2-39efdfb24a8b) |

The `disource` and `dvsource` aliases have also been added.