### PR TITLE
fix: wrong padding and spacing for logic gates

### DIFF
--- a/src/components/logic.typ
+++ b/src/components/logic.typ
@@ -7,14 +7,14 @@
 
     // Drawing function
     let draw(ctx, position, style) = {
-        let height = calc.max(style.min-height, inputs * style.spacing + 2 * style.padding)
+        let height = calc.max(style.min-height, (inputs - 1) * style.spacing + 2 * style.padding)
         interface((-style.width / 2, -height / 2), (style.width / 2, height / 2), io: false)
 
         rect((-style.width / 2, -height / 2), (rel: (style.width, height)), fill: style.fill, stroke: style.stroke)
         content((0, height / 2 - style.padding), text, anchor: "north")
 
         for input in range(1, inputs + 1) {
-            anchor("in" + str(input), (-style.width / 2, height / 2 - input * style.spacing))
+            anchor("in" + str(input), (-style.width / 2, height / 2 - style.padding - (input - 1) * style.spacing))
         }
 
         if invert {


### PR DESCRIPTION
<img width="448" height="508" alt="image" src="https://github.com/user-attachments/assets/814f52b4-a00f-4d26-8fab-1e619276db9b" />

_(Above: now, Below: before)_

If the `padding` isn't exactly half the `spacing`, the math doesn't add up. This should fix it.