### PR TITLE
feat: power supplies anchors for `opamp`

### DIFF
--- a/docs/main.typ
+++ b/docs/main.typ
@@ -1043,13 +1043,25 @@ The `diode` symbol accepts only one parameter, called `type`, and its appearance
     import zap: *
 
     opamp("o1", (0, 0))
-    opamp("o2", (3, 0), variant: "ieee")
+    opamp("o2", (5, 0), variant: "ieee")
 })
 ```)[
     #zap.circuit({
         import zap: *
+        import cetz.draw: *
         opamp("o1", (0, 0))
-        opamp("o2", (3, 0), variant: "ieee")
+        set-style(zap: (stub: (length: 0.4)))
+        opamp("o2", (5, 0), variant: "ieee")
+        wstub("o2.minus", label: "minus")
+        wstub("o2.plus", label: "plus")
+        nstub("o2.v", label: "v")
+        sstub("o2.g", label: "g")
+        estub("o2.out", label: "out")
+        wstub("o1.minus", label: "minus")
+        wstub("o1.plus", label: "plus")
+        nstub("o1.v", label: "v")
+        sstub("o1.g", label: "g")
+        estub("o1.out", label: "out")
     })
 ]
 

--- a/src/symbols/integrated/opamp.typ
+++ b/src/symbols/integrated/opamp.typ
@@ -17,12 +17,16 @@
         anchor("plus", (-style.width / 2, -sgn * style.sign-delta))
 
         if style.variant == "iec" {
-            rect((-style.width / 2, -style.height / 2), (style.width / 2, style.height / 2), fill: style.fill, stroke: style.stroke)
+            rect((-style.width / 2, -style.height / 2), (style.width / 2, style.height / 2), fill: style.fill, stroke: style.stroke, name: "shape")
+            anchor("v", "shape.north")
+            anchor("g", "shape.south")
         } else {
             scope({
                 if style.variant == "ieee" { translate((-style.width / 6, 0)) }
-                polygon((0, 0), 3, radius: style.width * 2 / 3, fill: style.fill, stroke: style.stroke)
+                polygon((0, 0), 3, radius: style.width * 2 / 3, fill: style.fill, stroke: style.stroke, name: "shape")
             })
+            anchor("v", "shape.edge-0")
+            anchor("g", "shape.edge-2")
         }
 
         set-style(stroke: style.sign-stroke)


### PR DESCRIPTION
Fixes #175 

This PR adds new power supplies anchors for `opamp`, like below

<img width="249" height="189" alt="Capture d’écran 2026-03-09 à 10 28 49" src="https://github.com/user-attachments/assets/3c5547e1-9379-4f9e-b7cf-451fad9c5a15" />
