### PR TITLE
feat: configurable logic inverter marker style

### DIFF
--- a/src/components/logic.typ
+++ b/src/components/logic.typ
@@ -4,14 +4,10 @@
 
 #let logic(name, node, text: $"&"$, invert: false, inputs: 2, ..params) = {
     assert(inputs >= 2, message: "logic supports minimum two inputs")
+    assert(invert in (true, false, "wedge"), message: "invert should be boolean or 'wedge'")
 
     // Drawing function
     let draw(ctx, position, style) = {
-        assert(
-            style.invert-style in ("triangle", "circle"),
-            message: "logic invert-style must be 'triangle' or 'circle'",
-        )
-
         let height = calc.max(style.min-height, (inputs - 1) * style.spacing + 2 * style.padding)
         interface((-style.width / 2, -height / 2), (style.width / 2, height / 2), io: false)
 
@@ -22,17 +18,15 @@
             anchor("in" + str(input), (-style.width / 2, height / 2 - style.padding - (input - 1) * style.spacing))
         }
 
-        if invert {
-            if style.invert-style == "circle" {
-                let radius = style.invert-width * 0.4
-                let spacing = style.invert-width * 0.05
-                circle((style.width / 2 + radius + spacing, 0), radius: radius, fill: style.fill, stroke: style.stroke)
-                anchor("out", (style.width / 2 + 2 * radius + spacing, 0))
-            } else {
-                line((style.width / 2, style.invert-height), (rel: (style.invert-width, -style.invert-height)))
-                line((style.width / 2, 0), (rel: (style.invert-width, 0)))
-                anchor("out", (style.width / 2 + style.invert-width, 0))
-            }
+        if invert == true {
+            let radius = style.invert-width * 0.4
+            let spacing = style.invert-width * 0.05
+            circle((style.width / 2 + radius + spacing, 0), radius: radius, fill: style.fill, stroke: style.stroke)
+            anchor("out", (style.width / 2 + 2 * radius + spacing, 0))
+        } else if invert == "wedge" {
+            line((style.width / 2, style.invert-height), (rel: (style.invert-width, -style.invert-height)))
+            line((style.width / 2, 0), (rel: (style.invert-width, 0)))
+            anchor("out", (style.width / 2 + style.invert-width, 0))
         } else {
             anchor("out", (style.width / 2, 0))
         }

--- a/src/styles.typ
+++ b/src/styles.typ
@@ -421,7 +421,6 @@
         width: 1.1,
         min-height: 1,
         padding: 0.2,
-        invert-style: "triangle",
         invert-width: 0.3,
         invert-height: 0.2,
         spacing: .4,


### PR DESCRIPTION
This PR adds support for a circle inversion marker, by introducing a configurable inverter style.
## What changed
- Added logic style option: `logic : (invert-style: "circle" | "triangle")` 
- Updated logic gate rendering to support circle inversion markers for inverted gates.
- Kept triangle behavior as the default to preserve backward compatibility.
- Added example for invert-style

## Notes 
- The circle marker is intentionally smaller for cleaner visual balance.
- Output anchoring was adjusted so wiring remains visually connected with the selected inversion marker style.
 <details>
<summary>Example image</summary>
<img width="1355" height="460" alt="image" src="https://github.com/user-attachments/assets/8cfc06bb-43e2-4f34-803f-41a91d872ea7" />
</details>

## Edits
- Moved the circle to the right by the stroke width to match industry adopted style. 
  <details>
  <summary>Example image</summary>
  <img width="1355" height="460" alt="image" src="https://github.com/user-attachments/assets/ca7f31c8-99d8-4413-ac65-6d3b1b3b4a71" />
  </details>
