### PR TITLE
docs(testing): Add docs for local testing and contributor test workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,14 +3,17 @@
 I'm glad you're reading this because it means you're interested in contributing to this project. We need developers who help this project grow 🌱!
 
 Here are some important resources:
+
 - [Repository](https://github.com/l0uisgrange/zap) holds the code and content of the `zap` package
 - [GitHub Issues](https://github.com/l0uisgrange/zap/issues) indicates everything you can work on (of course, you are free to propose anything else 😉)
 - [Discussions](https://github.com/l0uisgrange/zap/discussions) is where we talk about the package features and future
 - [Releases](https://github.com/l0uisgrange/zap/releases) represents the present and history of this package project
+- [Testing guide](./TESTING.md) explains how to run and update snapshot tests locally
 
 ## How to contribute
 
 Contributing to this project is straightforward:
+
 1. Fork the repository on your own profile and start coding
 2. When you're finished, update the documentation under the `docs` folder if necessary
 3. Push your commits to your own repository
@@ -20,9 +23,10 @@ And you're done!
 
 ## Guidelines
 
->[!WARNING]
->These guidelines are here to help keep this project well-organized and easy to manage for me.
+> [!WARNING]
+> These guidelines are here to help keep this project well-organized and easy to manage for me.
 
 1. Before submission, please execute `typstyle -l 180 -t 4 -i src` to get your code clean
-2. One Pull Request means one feature/component
-3. Communication is necessary, please give your Pull Request a short, descriptive title with a quick explanation of the feature you developed. PR names should start with `feat`, `feat(component)`, `docs`, `chore`, ... for example `feat: adding voltage decorations to components`
+2. Before submission, please run tests with `tt run --no-fail-fast`
+3. One Pull Request means one feature/component
+4. Communication is necessary, please give your Pull Request a short, descriptive title with a quick explanation of the feature you developed. PR names should start with `feat`, `feat(component)`, `docs`, `chore`, ... for example `feat: adding voltage decorations to components`

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,143 @@
+# Testing Guide
+
+This repository uses [Tytanic](https://github.com/tingerrr/tytanic) snapshot tests for Typst output.
+
+## What tests check
+
+- Each test under `tests/<name>/test.typ` renders one or more pages.
+- `ref/*.png` are the expected snapshots.
+- `out/*.png` are current render outputs.
+- `diff/*.png` are visual differences generated when output and reference differ.
+
+A test is:
+
+- `persistent`: has references and is compared against them.
+- `compile-only`: compiles but has no references yet.
+
+## Prerequisites
+
+Install the tools used by CI:
+
+```bash
+typst --version
+```
+
+If Typst is missing, install it with your preferred method.
+
+Install Tytanic CLI:
+
+```bash
+cargo install tytanic --locked --version 0.2.2
+```
+
+## Run tests locally
+
+Run all package tests:
+
+```bash
+tt run --no-fail-fast
+```
+
+Run one test suite only:
+
+```bash
+tt run logic
+```
+
+List available tests and their mode:
+
+```bash
+tt list
+```
+
+## Update snapshots (references)
+
+Update all persistent references:
+
+```bash
+tt update
+```
+
+Update one suite only:
+
+```bash
+tt update logic
+```
+
+After updating, run tests again:
+
+```bash
+tt run --no-fail-fast
+```
+
+## Create a new test
+
+1. Add a file: `tests/<name>/test.typ`.
+2. Import the shared helper:
+
+```typst
+#import "/tests/utils.typ": test
+#import "/src/lib.typ"
+
+#test({
+    import lib: *
+    // your symbol calls
+})
+```
+
+3. Generate first references:
+
+```bash
+tt update <name>
+```
+
+4. Verify:
+
+```bash
+tt run <name>
+```
+
+## Common issues
+
+### "attempted to update compile-only test"
+
+Cause: the test has no references yet, so it is marked compile-only.
+
+Fix:
+
+1. Run the test once:
+
+```bash
+tt run <name>
+```
+
+2. If needed, seed references from output:
+
+```bash
+mkdir -p tests/<name>/ref
+cp tests/<name>/out/*.png tests/<name>/ref/
+```
+
+3. Re-run and then update normally:
+
+```bash
+tt run <name>
+tt update <name>
+```
+
+### Avoid manual PDF extraction for references
+
+Do not create `ref/*.png` with external PDF/image tools.
+Those tools can change dimensions and antialiasing, leading to false diffs.
+Always generate references via `tt run`/`tt update`.
+
+## CI parity commands
+
+The CI workflow in `.github/workflows/test.yml` runs:
+
+```bash
+tt run --no-fail-fast
+typst compile docs/main.typ --format html --features html --root .
+```
+
+Running both locally is the closest match to CI behavior.


### PR DESCRIPTION
This PR adds documentation for running and maintaining the Typst tests suite locally. 

 # What changed 
 Added a new testing guide with end-to-end local workflow:
 - running tests
-  prerequisites
- updating snapshots
- creating new tests
- CI parity commands
- common troubleshooting

Updated contribution docs to:

- link to the testing guide
- require running tests before submission 