### PR TITLE
refactor(src): switch internal imports to relative paths

### DIFF
--- a/src/circuit.typ
+++ b/src/circuit.typ
@@ -1,5 +1,5 @@
-#import "/src/dependencies.typ": cetz
-#import "/src/styles.typ": default
+#import "./dependencies.typ": cetz
+#import "./styles.typ": default
 
 #let circuit(fallback, ..params) = {
     cetz.canvas(..params, {

--- a/src/component.typ
+++ b/src/component.typ
@@ -1,8 +1,8 @@
-#import "dependencies.typ": cetz
-#import "decorations.typ": current, flow, voltage
-#import "components/node.typ": node
-#import "components/wire.typ": wire
-#import "utils.typ": expand-stroke, get-label-anchor, get-style, opposite-anchor, resolve-style
+#import "./dependencies.typ": cetz
+#import "./decorations.typ": current, flow, voltage
+#import "./components/node.typ": node
+#import "./components/wire.typ": wire
+#import "./utils.typ": expand-stroke, get-label-anchor, get-style, opposite-anchor, resolve-style
 #import cetz.styles: merge
 #import cetz.util: merge-dictionary
 

--- a/src/components/antenna.typ
+++ b/src/components/antenna.typ
@@ -1,7 +1,7 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
+#import "../component.typ": component, interface
+#import "../dependencies.typ": cetz
 #import cetz.draw: anchor, line, merge-path
-#import "/src/components/wire.typ": wire
+#import "./wire.typ": wire
 
 #let antenna(name, node, closed: false, ..params) = {
     // Drawing function

--- a/src/components/button.typ
+++ b/src/components/button.typ
@@ -1,8 +1,8 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
+#import "../component.typ": component, interface
+#import "../dependencies.typ": cetz
 #import cetz.draw: anchor, circle, hide, hobby, line, mark, merge-path, rect
-#import "/src/components/wire.typ": wire
-#import "/src/mini.typ": lamp
+#import "./wire.typ": wire
+#import "../mini.typ": lamp
 
 #let button(name, node, nc: false, illuminated: false, head: "standard", latching: false, ..params) = {
     // Drawing function

--- a/src/components/capacitor.typ
+++ b/src/components/capacitor.typ
@@ -1,7 +1,7 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
+#import "../component.typ": component, interface
+#import "../dependencies.typ": cetz
 #import cetz.draw: anchor, arc, line, merge-path, rect, set-style
-#import "/src/mini.typ": adjust-arrow
+#import "../mini.typ": adjust-arrow
 
 #let capacitor(name, node, variable: false, preset: false, sensor: false, polarized: false, ..params) = {
     assert(type(variable) == bool, message: "variable must be of type bool")

--- a/src/components/circulator.typ
+++ b/src/components/circulator.typ
@@ -1,7 +1,7 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
-#import "/src/mini.typ": ac-sign
-#import "/src/utils.typ": get-style
+#import "../component.typ": component, interface
+#import "../dependencies.typ": cetz
+#import "../mini.typ": ac-sign
+#import "../utils.typ": get-style
 #import cetz.draw: anchor, arc-through, circle, rotate
 
 #let circulator(name, node, ..params) = {

--- a/src/components/diode.typ
+++ b/src/components/diode.typ
@@ -1,8 +1,8 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
-#import "/src/mini.typ": radiation-arrows
-#import "/src/components/wire.typ": wire
-#import "/src/utils.typ": get-style
+#import "../component.typ": component, interface
+#import "../dependencies.typ": cetz
+#import "../mini.typ": radiation-arrows
+#import "./wire.typ": wire
+#import "../utils.typ": get-style
 #import cetz.draw: anchor, circle, line, merge-path, polygon, scope, set-style, translate
 
 #let diode(name, node, type: none, ..params) = {

--- a/src/components/fuse.typ
+++ b/src/components/fuse.typ
@@ -1,6 +1,6 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
-#import "/src/components/wire.typ": wire
+#import "../component.typ": component, interface
+#import "../dependencies.typ": cetz
+#import "./wire.typ": wire
 #import cetz.draw: anchor, circle, floating, line, rect, set-style
 
 #let fuse(name, node, asymmetric: false, ..params) = {

--- a/src/components/inductor.typ
+++ b/src/components/inductor.typ
@@ -1,6 +1,6 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
-#import "/src/mini.typ": adjust-arrow
+#import "../component.typ": component, interface
+#import "../dependencies.typ": cetz
+#import "../mini.typ": adjust-arrow
 #import cetz.draw: anchor, arc, line, merge-path, rect, set-style
 
 #let inductor(name, node, variable: false, preset: false, sensor: false, ..params) = {

--- a/src/components/instruments/round-meter.typ
+++ b/src/components/instruments/round-meter.typ
@@ -1,7 +1,7 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
-#import "/src/mini.typ": ac-sign
-#import "/src/utils.typ": get-style
+#import "../../component.typ": component, interface
+#import "../../dependencies.typ": cetz
+#import "../../mini.typ": ac-sign
+#import "../../utils.typ": get-style
 #import cetz.draw: anchor, circle, content, line, mark, polygon, rect
 
 #let round-meter(name, node, measurand: str, ..params) = {

--- a/src/components/integrated/converter.typ
+++ b/src/components/integrated/converter.typ
@@ -1,5 +1,5 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
+#import "../../component.typ": component, interface
+#import "../../dependencies.typ": cetz
 #import cetz.draw: anchor, content, line, merge-path, on-layer, polygon, rect, scale, scope, translate
 
 #let adc(name, node, input: "a", label: "ADC", ..params) = {

--- a/src/components/integrated/flipflop.typ
+++ b/src/components/integrated/flipflop.typ
@@ -1,6 +1,6 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
-#import "/src/mini.typ": clock-wedge
+#import "../../component.typ": component, interface
+#import "../../dependencies.typ": cetz
+#import "../../mini.typ": clock-wedge
 #import cetz.draw: anchor, content, line, polygon, rect, scope, translate
 
 #let flipflop(name, node, pins: (:), ..params) = {

--- a/src/components/integrated/mcu.typ
+++ b/src/components/integrated/mcu.typ
@@ -1,5 +1,5 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
+#import "../../component.typ": component, interface
+#import "../../dependencies.typ": cetz
 #import cetz.draw: anchor, content, line, polygon, rect, scope, translate
 
 #let opposite-anchor(side) = {

--- a/src/components/integrated/opamp.typ
+++ b/src/components/integrated/opamp.typ
@@ -1,5 +1,5 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
+#import "../../component.typ": component, interface
+#import "../../dependencies.typ": cetz
 #import cetz.draw: anchor, content, line, polygon, rect, scope, set-style, translate
 
 #let opamp(name, node, invert: false, label: none, ..params) = {

--- a/src/components/logic.typ
+++ b/src/components/logic.typ
@@ -1,5 +1,5 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
+#import "../component.typ": component, interface
+#import "../dependencies.typ": cetz
 #import cetz.draw: anchor, arc-through, circle, content, line, rect, rotate
 
 #let logic(name, node, text: $"&"$, invert: false, inputs: 2, ..params) = {

--- a/src/components/motor.typ
+++ b/src/components/motor.typ
@@ -1,6 +1,6 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
-#import "/src/mini.typ": ac-sign, dc-sign
+#import "../component.typ": component, interface
+#import "../dependencies.typ": cetz
+#import "../mini.typ": ac-sign, dc-sign
 #import cetz.draw: anchor, arc, circle, content, rect
 
 #let motor(uid, name, node, current: "dc", magnet: false, ..params) = {

--- a/src/components/node.typ
+++ b/src/components/node.typ
@@ -1,5 +1,5 @@
-#import "/src/dependencies.typ": cetz
-#import "/src/utils.typ": get-style, opposite-anchor
+#import "../dependencies.typ": cetz
+#import "../utils.typ": get-style, opposite-anchor
 #import cetz.draw: circle, content, get-ctx, on-layer
 
 #let node(name, position, fill: true, label: none, ..params) = {

--- a/src/components/resistor.typ
+++ b/src/components/resistor.typ
@@ -1,6 +1,6 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
-#import "/src/mini.typ": adjust-arrow, adjustable-arrow
+#import "../component.typ": component, interface
+#import "../dependencies.typ": cetz
+#import "../mini.typ": adjust-arrow, adjustable-arrow
 #import cetz.draw: anchor, line, rect, set-style
 
 #let resistor(name, node, variable: false, heatable: false, adjustable: false, preset: false, sensor: false, ..params) = {

--- a/src/components/source.typ
+++ b/src/components/source.typ
@@ -1,7 +1,7 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
-#import "/src/mini.typ": ac-sign
-#import "/src/utils.typ": get-style
+#import "../component.typ": component, interface
+#import "../dependencies.typ": cetz
+#import "../mini.typ": ac-sign
+#import "../utils.typ": get-style
 #import cetz.draw: anchor, circle, content, line, mark, polygon, rect, set-style
 
 #let isource(name, node, dependent: false, current: "dc", ..params) = {

--- a/src/components/stub.typ
+++ b/src/components/stub.typ
@@ -1,8 +1,8 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
-#import "/src/mini.typ": ac-sign
-#import "/src/utils.typ": get-style, opposite-anchor
-#import "/src/components/wire.typ": wire
+#import "../component.typ": component, interface
+#import "../dependencies.typ": cetz
+#import "../mini.typ": ac-sign
+#import "../utils.typ": get-style, opposite-anchor
+#import "./wire.typ": wire
 #import cetz.draw: anchor, circle, content, line, mark, polygon, rect, set-style
 
 #let stub(node, dir: "north", ..params) = {

--- a/src/components/supply.typ
+++ b/src/components/supply.typ
@@ -1,6 +1,6 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
-#import "/src/components/wire.typ": wire
+#import "../component.typ": component, interface
+#import "../dependencies.typ": cetz
+#import "./wire.typ": wire
 #import cetz.draw: anchor, line, polygon, scale, scope, set-style
 
 #let ground(name, node, ..params) = {

--- a/src/components/switch.typ
+++ b/src/components/switch.typ
@@ -1,6 +1,6 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
-#import "/src/components/wire.typ": wire
+#import "../component.typ": component, interface
+#import "../dependencies.typ": cetz
+#import "./wire.typ": wire
 #import cetz.draw: anchor, circle, hide, line, mark, rect
 
 #let switch(name, node, closed: false, ..params) = {

--- a/src/components/transformer.typ
+++ b/src/components/transformer.typ
@@ -1,5 +1,5 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
+#import "../component.typ": component, interface
+#import "../dependencies.typ": cetz
 #import cetz.draw: anchor, circle, hide, line, mark, merge-path, rect, set-style
 
 #let transformer(name, node, ..params) = {

--- a/src/components/transistors/bjt.typ
+++ b/src/components/transistors/bjt.typ
@@ -1,8 +1,8 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
-#import "/src/mini.typ": center-mark
-#import "/src/components/wire.typ": wire
-#import "/src/utils.typ": get-style
+#import "../../component.typ": component, interface
+#import "../../dependencies.typ": cetz
+#import "../../mini.typ": center-mark
+#import "../wire.typ": wire
+#import "../../utils.typ": get-style
 #import cetz.draw: anchor, circle, content, hide, line, mark, set-style, translate
 
 #let bjt(name, node, polarisation: "npn", envelope: false, ..params) = {

--- a/src/components/transistors/mosfet.typ
+++ b/src/components/transistors/mosfet.typ
@@ -1,6 +1,6 @@
-#import "/src/component.typ": component, interface
-#import "/src/dependencies.typ": cetz
-#import "/src/components/wire.typ": wire
+#import "../../component.typ": component, interface
+#import "../../dependencies.typ": cetz
+#import "../wire.typ": wire
 #import cetz.draw: anchor, circle, content, floating, hide, line, mark, scale, set-origin, set-style, translate
 
 #let mosfet(

--- a/src/components/wire.typ
+++ b/src/components/wire.typ
@@ -1,5 +1,5 @@
-#import "/src/dependencies.typ": cetz
-#import "/src/utils.typ": get-style, opposite-anchor, resolve-style
+#import "../dependencies.typ": cetz
+#import "../utils.typ": get-style, opposite-anchor, resolve-style
 #import cetz.draw: anchor, circle, content, group, hide, line, mark, set-style
 #import cetz.styles: merge
 

--- a/src/decorations.typ
+++ b/src/decorations.typ
@@ -1,5 +1,5 @@
-#import "/src/dependencies.typ": cetz
-#import "/src/utils.typ": get-style, resolve-style
+#import "./dependencies.typ": cetz
+#import "./utils.typ": get-style, resolve-style
 #import cetz.draw: bezier-through, catmull, circle, content, hobby, line, mark
 #import cetz.styles: merge
 

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -1,41 +1,41 @@
 // Export dependencies
-#import "dependencies.typ": cetz
+#import "./dependencies.typ": cetz
 #import cetz: draw
 
 // Export circuit
-#import "circuit.typ": circuit
+#import "./circuit.typ": circuit
 
 // Export utils
-#import "utils.typ": set-style
+#import "./utils.typ": set-style
 
 // Export styles
-#import "styles.typ"
+#import "./styles.typ"
 
 // Export core
-#import "component.typ": component, interface
+#import "./component.typ": component, interface
 
 // Export components
-#import "components/antenna.typ": antenna
-#import "components/transformer.typ": transformer
-#import "components/stub.typ": estub, nstub, sstub, stub, wstub
-#import "components/wire.typ": swire, wire, zwire
-#import "components/circulator.typ": circulator
-#import "components/node.typ": node
-#import "components/capacitor.typ": capacitor, pcapacitor
-#import "components/diode.typ": diode, led, photodiode, schottky, tunnel, zener
-#import "components/switch.typ": switch
-#import "components/fuse.typ": afuse, fuse
-#import "components/supply.typ": earth, frame, ground, rground, vcc, vee
-#import "components/inductor.typ": inductor
-#import "components/logic.typ": land, lnand, lnor, lnot, lor, lxnor, lxor
-#import "components/resistor.typ": heater, potentiometer, resistor, rheostat
-#import "components/source.typ": acvsource, disource, dvsource, isource, vsource
-#import "components/motor.typ": acmotor, dcmotor
-#import "components/transistors/bjt.typ": bjt, npn, pnp
-#import "components/transistors/mosfet.typ": mosfet, nmos, nmosd, pmos, pmosd
-#import "components/integrated/opamp.typ": opamp
-#import "components/integrated/mcu.typ": mcu
-#import "components/integrated/converter.typ": adc, dac
-#import "components/instruments/round-meter.typ": ammeter, ohmmeter, round-meter, voltmeter, wattmeter
-#import "components/button.typ": button, ncbutton, ncibutton, nobutton, noibutton
-#import "components/integrated/flipflop.typ": dflipflop, flipflop, jkflipflop, srlatch
+#import "./components/antenna.typ": antenna
+#import "./components/transformer.typ": transformer
+#import "./components/stub.typ": estub, nstub, sstub, stub, wstub
+#import "./components/wire.typ": swire, wire, zwire
+#import "./components/circulator.typ": circulator
+#import "./components/node.typ": node
+#import "./components/capacitor.typ": capacitor, pcapacitor
+#import "./components/diode.typ": diode, led, photodiode, schottky, tunnel, zener
+#import "./components/switch.typ": switch
+#import "./components/fuse.typ": afuse, fuse
+#import "./components/supply.typ": earth, frame, ground, rground, vcc, vee
+#import "./components/inductor.typ": inductor
+#import "./components/logic.typ": land, lnand, lnor, lnot, lor, lxnor, lxor
+#import "./components/resistor.typ": heater, potentiometer, resistor, rheostat
+#import "./components/source.typ": acvsource, disource, dvsource, isource, vsource
+#import "./components/motor.typ": acmotor, dcmotor
+#import "./components/transistors/bjt.typ": bjt, npn, pnp
+#import "./components/transistors/mosfet.typ": mosfet, nmos, nmosd, pmos, pmosd
+#import "./components/integrated/opamp.typ": opamp
+#import "./components/integrated/mcu.typ": mcu
+#import "./components/integrated/converter.typ": adc, dac
+#import "./components/instruments/round-meter.typ": ammeter, ohmmeter, round-meter, voltmeter, wattmeter
+#import "./components/button.typ": button, ncbutton, ncibutton, nobutton, noibutton
+#import "./components/integrated/flipflop.typ": dflipflop, flipflop, jkflipflop, srlatch

--- a/src/mini.typ
+++ b/src/mini.typ
@@ -1,5 +1,5 @@
-#import "dependencies.typ": cetz
-#import "utils.typ": get-style
+#import "./dependencies.typ": cetz
+#import "./utils.typ": get-style
 #import cetz.draw: anchor, circle, hobby, line, merge-path, rotate, scope, set-origin, set-style
 #import cetz.styles: merge
 

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -73,7 +73,7 @@
     return dict
 }
 
-#import "/src/dependencies.typ": cetz
+#import "./dependencies.typ": cetz
 
 #let resolve(dict) = {
     // Special dictionaries

--- a/tests/antenna/test.typ
+++ b/tests/antenna/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 // Test symbols
 #test({

--- a/tests/button/test.typ
+++ b/tests/button/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 // Test symbols
 #test({

--- a/tests/capacitor/test.typ
+++ b/tests/capacitor/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 // Test symbols
 #test({

--- a/tests/component/test.typ
+++ b/tests/component/test.typ
@@ -1,6 +1,6 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
-#import "/src/dependencies.typ": cetz
+#import "../utils.typ": test
+#import "../../src/lib.typ"
+#import "../../src/dependencies.typ": cetz
 
 // Test rotation
 #test({

--- a/tests/converter/test.typ
+++ b/tests/converter/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 // Test symbols
 #test({

--- a/tests/custom/test.typ
+++ b/tests/custom/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ": cetz, component, interface, set-style
+#import "../utils.typ": test
+#import "../../src/lib.typ": cetz, component, interface, set-style
 
 #let custom(name, ..params) = {
     let const = (w: 2, h: 1)

--- a/tests/diode/test.typ
+++ b/tests/diode/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 // Test symbols
 #test({

--- a/tests/examples/test.typ
+++ b/tests/examples/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 #let pins = (
     (content: "VCC", side: "west"),

--- a/tests/fuse/test.typ
+++ b/tests/fuse/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 // Test symbols
 #test({

--- a/tests/inductor/test.typ
+++ b/tests/inductor/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 // Test symbols
 #test({

--- a/tests/instruments/test.typ
+++ b/tests/instruments/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 // Test symbols
 #test({

--- a/tests/isource/test.typ
+++ b/tests/isource/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 // Test symbols
 #test({

--- a/tests/mcu/test.typ
+++ b/tests/mcu/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 #let pins = (
     (content: "VCC", side: "west"),

--- a/tests/node/test.typ
+++ b/tests/node/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 // Test symbols
 #test({

--- a/tests/opamp/test.typ
+++ b/tests/opamp/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 // Test symbols
 #test({

--- a/tests/resistor/test.typ
+++ b/tests/resistor/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 // Test symbols
 #test({

--- a/tests/styles/test.typ
+++ b/tests/styles/test.typ
@@ -1,6 +1,6 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
-#import "/src/dependencies.typ": cetz
+#import "../utils.typ": test
+#import "../../src/lib.typ"
+#import "../../src/dependencies.typ": cetz
 
 // Test CeTZ components styling
 #test({

--- a/tests/supplies/test.typ
+++ b/tests/supplies/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 // Test symbols
 #test({

--- a/tests/switch/test.typ
+++ b/tests/switch/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 // Test symbols
 #test({

--- a/tests/transformer/test.typ
+++ b/tests/transformer/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 // Test symbols
 #test({

--- a/tests/transistors/test.typ
+++ b/tests/transistors/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 // Test symbols
 #test({

--- a/tests/utils.typ
+++ b/tests/utils.typ
@@ -1,4 +1,4 @@
-#import "/src/lib.typ" as lib
+#import "../src/lib.typ" as lib
 
 #let test(body) = {
     set page(margin: 4pt, width: auto, height: auto)

--- a/tests/vsource/test.typ
+++ b/tests/vsource/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 // Test symbols
 #test({

--- a/tests/wire/test.typ
+++ b/tests/wire/test.typ
@@ -1,5 +1,5 @@
-#import "/tests/utils.typ": test
-#import "/src/lib.typ"
+#import "../utils.typ": test
+#import "../../src/lib.typ"
 
 // Test symbols
 #test({


### PR DESCRIPTION
Refactor Zap's internal imports to use relative paths throughout `src`, so the package can be used cleanly as a submodule in another repository. 

This changes import resolution and does not change the runtime behaviour 

This is just a proposal and may not be intended for zap, but for me this is a "feature" that is quite relevant.